### PR TITLE
Change 9anime mirror

### DIFF
--- a/NineAnimeProvider/src/main/kotlin/com/stormunblessed/NineAnimeProvider.kt
+++ b/NineAnimeProvider/src/main/kotlin/com/stormunblessed/NineAnimeProvider.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.delay
 
 
 class NineAnimeProvider : MainAPI() {
-    override var mainUrl = "https://9anime.id"
+    override var mainUrl = "https://9anime.pl"
     override var name = "9Anime"
     override val hasMainPage = true
     override val hasChromecastSupport = true


### PR DESCRIPTION
Cloning to .pl domain fixed the 9anime not working issue people had in all the cases I suggested it , so changing it to this as default may be helpful